### PR TITLE
optimize split_by() - avoid copying @_ and use splice()

### DIFF
--- a/lib/Array/Split.pm
+++ b/lib/Array/Split.pm
@@ -26,16 +26,13 @@ or less than $split_size, with the last one usually being the one to have less i
 =cut
 
 sub split_by {
-    my ( $split_size, @original ) = @_;
+    my $split_size = shift;
 
-    $split_size = ceil max( $split_size, 1 );
+    $split_size = max( $split_size, 1 );
 
     my @sub_arrays;
-    for my $element ( @original ) {
-        push @sub_arrays, [] if !@sub_arrays;
-        push @sub_arrays, [] if @{ $sub_arrays[-1] } >= $split_size;
-
-        push @{ $sub_arrays[-1] }, $element;
+    while ( @_ ) {
+        push @sub_arrays, [ splice @_, 0, $split_size ];
     }
 
     return @sub_arrays;


### PR DESCRIPTION
My simple [benchmark](https://gist.github.com/xenu/5424f6a4594bf7bd49bb0bb6f5ae946d) shows over 800% performance improvement:

```
       Rate orig  new
orig 37.9/s   -- -89%
new   358/s 843%   --
```

Note that I also have removed `ceil()` on `$split_size`. It seemed to be redundant, nothing in the docs suggest that this function takes floats. 

Passing floats will still work, but instead of rounding them up, `splice` will simply cast them to an integer.